### PR TITLE
Prevent Chrome from GCing when creating iframe

### DIFF
--- a/jscripts/tiny_mce/classes/Editor.js
+++ b/jscripts/tiny_mce/classes/Editor.js
@@ -559,6 +559,12 @@
 			}
 
 			// Create iframe
+
+			// Prevent chrome from GC'ing when creating iframe
+			if ($.browser.chrome && !!window.chrome) {
+				u = u || 'about:blank';
+			}
+
 			// TODO: ACC add the appropriate description on this.
 			n = DOM.add(o.iframeContainer, 'iframe', { 
 				id : t.id + "_ifr",


### PR DESCRIPTION
We previously had this tidbit of code in our vendored version.

Chrome was triggering GC when using `"javascript://"` as the iframe src. Replacing it to `"about:blank"` appeared to fix the issue.
