### PR TITLE
Do not remove empty anchor tags that have a class

### DIFF
--- a/jscripts/tiny_mce/classes/html/DomParser.js
+++ b/jscripts/tiny_mce/classes/html/DomParser.js
@@ -520,8 +520,8 @@
 								if (elementRule.paddEmpty)
 									node.empty().append(new Node('#text', '3')).value = '\u00a0';
 								else {
-									// Leave nodes that have a name like <a name="name">
-									if (!node.attributes.map.name && !node.attributes.map.id) {
+									// Leave nodes that have a name like <a name="name"> or a class like <a class="class"></a>
+									if (!node.attributes.map.name && !node.attributes.map.id && !node.attributes.map['class']) {
 										tempNode = node.parent;
 										node.empty().remove();
 										node = tempNode;

--- a/jscripts/tiny_mce/classes/html/Node.js
+++ b/jscripts/tiny_mce/classes/html/Node.js
@@ -415,11 +415,11 @@
 						if (elements[node.name])
 							return false;
 
-						// Keep elements with data attributes or name attribute like <a name="1"></a>
+						// Keep elements with data attributes or name attribute like <a name="1"></a> or class attribute like <a class="1"></a>
 						i = node.attributes.length;
 						while (i--) {
 							name = node.attributes[i].name;
-							if (name === "name" || name.indexOf('data-mce-') === 0)
+							if (name === "name" || name === "class" || name.indexOf('data-mce-') === 0)
 								return false;
 						}
 					}


### PR DESCRIPTION
TinyMCE currently removes `<a class="test"></a>` because there is no content and no `name` attribute.

This addresses Shopify/shopify#4745.
