### PR TITLE
Defer function call in TinyMCE to prevent exceeding call stack

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1003,7 +1003,9 @@ define("tinymce/Editor", [
 					// WebKit needs this call to fire focusin event properly see #5948
 					// But Opera pre Blink engine will produce an empty selection so skip Opera
 					if (!Env.opera) {
-						self.getBody().focus();
+						setTimeout(function () {
+							self.getBody().focus();
+						}, 0);
 					}
 
 					self.getWin().focus();


### PR DESCRIPTION
Bug and solution explanation: https://github.com/Shopify/shopify/pull/25532
Fixes https://github.com/Shopify/shopify/issues/25529

@angelini @kmcphillips 
