### PR TITLE
Update TinyMCE with upstream

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 Version 4.1.5 (2014-08-xx)
 	Fixed bug where sometimes the resize rectangles wouldn't properly render on images on WebKit/Blink.
+	Fixed bug in list plugin where delete/backspace would merge empty LI elements in lists incorrectly.
 Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version 4.1.5 (2014-08-xx)
 	Fixed bug in list plugin where delete/backspace would merge empty LI elements in lists incorrectly.
 	Fixed bug where empty list elements would result in empty LI elements without it's parent container.
 	Fixed bug where backspace in empty caret formated element could produce an type error exception of Gecko.
+	Fixed bug where lists pasted from word with a custom start index above 9 wouldn't be properly handled.
 Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Version 4.1.4 (2014-xx-xx)
 	Fixed bug where the spellchecker menu item wouldn't be properly checked if spell checking was started before it was rendered.
 	Fixed bug where the DomQuery filter function wouldn't remove non elements from collection.
 	Fixed bug where document with custom document.domain wouldn't properly render the editor.
+	Fixed so the color picker button in table dialog isn't shown unless you include the colorpicker plugin or add your own custom color picker.
 	Fixed so activate/deactivate events fire when windowManager opens a window since.
 	Fixed so the table advtab options isn't separated by an underscore to normalize naming with image_advtab option.
 Version 4.1.3 (2014-07-29)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+Version 4.1.5 (2014-08-xx)
+	Fixed bug where sometimes the resize rectangles wouldn't properly render on images on WebKit/Blink.
 Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Version 4.1.4 (2014-xx-xx)
+Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.
 	Fixed bug where activate/deactivate events wasn't firing properly when switching between editors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Version 4.1.4 (2014-xx-xx)
 	Fixed bug where the spellchecker menu item wouldn't be properly checked if spell checking was started before it was rendered.
 	Fixed bug where the DomQuery filter function wouldn't remove non elements from collection.
 	Fixed bug where document with custom document.domain wouldn't properly render the editor.
+	Fixed bug where IE 8 would throw exception when trying to enter invalid color values into colorboxes.
 	Fixed so the color picker button in table dialog isn't shown unless you include the colorpicker plugin or add your own custom color picker.
 	Fixed so activate/deactivate events fire when windowManager opens a window since.
 	Fixed so the table advtab options isn't separated by an underscore to normalize naming with image_advtab option.

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@ Version 4.1.4 (2014-xx-xx)
 	Fixed bug where the DomQuery filter function wouldn't remove non elements from collection.
 	Fixed bug where document with custom document.domain wouldn't properly render the editor.
 	Fixed bug where IE 8 would throw exception when trying to enter invalid color values into colorboxes.
+	Fixed bug where undo manager could incorrectly add an extra undo level when custom resize handles was removed.
 	Fixed so the color picker button in table dialog isn't shown unless you include the colorpicker plugin or add your own custom color picker.
 	Fixed so activate/deactivate events fire when windowManager opens a window since.
 	Fixed so the table advtab options isn't separated by an underscore to normalize naming with image_advtab option.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 Version 4.1.5 (2014-08-xx)
 	Fixed bug where sometimes the resize rectangles wouldn't properly render on images on WebKit/Blink.
 	Fixed bug in list plugin where delete/backspace would merge empty LI elements in lists incorrectly.
+	Fixed bug where empty list elements would result in empty LI elements without it's parent container.
 Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Version 4.1.5 (2014-08-xx)
 	Fixed bug where sometimes the resize rectangles wouldn't properly render on images on WebKit/Blink.
 	Fixed bug in list plugin where delete/backspace would merge empty LI elements in lists incorrectly.
 	Fixed bug where empty list elements would result in empty LI elements without it's parent container.
+	Fixed bug where backspace in empty caret formated element could produce an type error exception of Gecko.
 Version 4.1.4 (2014-08-21)
 	Added new media_filter_html option to media plugin that blocks any conditional comments, scripts etc within a video element.
 	Added new content_security_policy option allows you to set custom policy for iframe contents. Patch contributed by Francois Chagnon.

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Version 4.1.4 (2014-xx-xx)
 	Fixed so the color picker button in table dialog isn't shown unless you include the colorpicker plugin or add your own custom color picker.
 	Fixed so activate/deactivate events fire when windowManager opens a window since.
 	Fixed so the table advtab options isn't separated by an underscore to normalize naming with image_advtab option.
+	Fixed so the table cell dialog has proper padding when the advanced tab in disabled.
 Version 4.1.3 (2014-07-29)
 	Added event binding logic to tinymce.util.XHR making it possible to override headers and settings before any request is made.
 	Fixed bug where drag events wasn't fireing properly on older IE versions since the event handlers where bound to document.

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@ Version 4.1.4 (2014-xx-xx)
 	Fixed bug where document with custom document.domain wouldn't properly render the editor.
 	Fixed bug where IE 8 would throw exception when trying to enter invalid color values into colorboxes.
 	Fixed bug where undo manager could incorrectly add an extra undo level when custom resize handles was removed.
+	Fixed bug where it wouldn't be possible to alter cell properties properly on table cells on IE 8.
 	Fixed so the color picker button in table dialog isn't shown unless you include the colorpicker plugin or add your own custom color picker.
 	Fixed so activate/deactivate events fire when windowManager opens a window since.
 	Fixed so the table advtab options isn't separated by an underscore to normalize naming with image_advtab option.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+machine:
+  node:
+    version: v0.10.26
+
+dependencies:
+  pre:
+    - npm install -g phantomjs

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1812,6 +1812,8 @@ define("tinymce/Editor", [
 				content = body.innerHTML;
 			} else if (args.format == 'text') {
 				content = body.innerText || body.textContent;
+			} else if (args.format == 'unvalidated_html') {
+				content = self.serializer.serialize_without_validation(body, args);
 			} else {
 				content = self.serializer.serialize(body, args);
 			}

--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -1751,7 +1751,7 @@ define("tinymce/Editor", [
 				self.fire('SetContent', args);
 			} else {
 				// Parse and serialize the html
-				if (args.format !== 'raw') {
+				if (args.format !== 'raw' && args.format !== 'unvalidated_html') {
 					content = new Serializer({}, self.schema).serialize(
 						self.parser.parse(content, {isRootContent: true})
 					);

--- a/js/tinymce/classes/FocusManager.js
+++ b/js/tinymce/classes/FocusManager.js
@@ -86,7 +86,11 @@ define("tinymce/FocusManager", [
 				if (editor.inline || Env.ie) {
 					// Use the onbeforedeactivate event when available since it works better see #7023
 					if ("onbeforedeactivate" in document && Env.ie < 9) {
-						editor.dom.bind(editor.getBody(), 'beforedeactivate', function() {
+						editor.dom.bind(editor.getBody(), 'beforedeactivate', function(e) {
+							if (e.target != editor.getBody()) {
+								return;
+							}
+
 							try {
 								editor.lastRng = editor.selection.getRng();
 							} catch (ex) {
@@ -197,7 +201,7 @@ define("tinymce/FocusManager", [
 						}
 
 						// Fire a blur event if the element isn't a UI element
-						if (!isUIElement(e.target) && editorManager.focusedEditor == activeEditor) {
+						if (e.target != document.body && !isUIElement(e.target) && editorManager.focusedEditor == activeEditor) {
 							activeEditor.fire('blur', {focusedEditor: null});
 							editorManager.focusedEditor = null;
 						}

--- a/js/tinymce/classes/Formatter.js
+++ b/js/tinymce/classes/Formatter.js
@@ -2040,12 +2040,12 @@ define("tinymce/Formatter", [
 							child.deleteData(0, 1);
 
 							// Fix for bug #6976
-							if (rng.startContainer == child) {
-								rng.startOffset--;
+							if (rng.startContainer == child && rng.startOffset > 0) {
+								rng.setStart(child, rng.startOffset - 1);
 							}
 
-							if (rng.endContainer == child) {
-								rng.endOffset--;
+							if (rng.endContainer == child && rng.endOffset > 0) {
+								rng.setEnd(child, rng.endOffset - 1);
 							}
 						}
 

--- a/js/tinymce/classes/NodeChange.js
+++ b/js/tinymce/classes/NodeChange.js
@@ -91,7 +91,11 @@ define("tinymce/NodeChange", [
 		// Fire an extra nodeChange on mouseup for compatibility reasons
 		editor.on('MouseUp', function(e) {
 			if (!e.isDefaultPrevented()) {
-				editor.nodeChanged();
+				// Delay nodeChanged call for WebKit edge case issue where the range
+				// isn't updated until after you click outside a selected image
+				setTimeout(function() {
+					editor.nodeChanged();
+				}, 0);
 			}
 		});
 
@@ -106,7 +110,7 @@ define("tinymce/NodeChange", [
 			var selection = editor.selection, node, parents, root;
 
 			// Fix for bug #1896577 it seems that this can not be fired while the editor is loading
-			if (editor.initialized && !editor.settings.disable_nodechange && !editor.settings.readonly) {
+			if (editor.initialized && selection && !editor.settings.disable_nodechange && !editor.settings.readonly) {
 				// Get start node
 				root = editor.getBody();
 				node = selection.getStart() || root;

--- a/js/tinymce/classes/NodeChange.js
+++ b/js/tinymce/classes/NodeChange.js
@@ -82,8 +82,8 @@ define("tinymce/NodeChange", [
 		editor.on('SelectionChange', function() {
 			var startElm = editor.selection.getStart(true);
 
-			// Selection change might fire when focus is lost so check if the start is still within the body
-			if (!isSameElementPath(startElm) && editor.dom.isChildOf(startElm, editor.getBody())) {
+			// Fire a nodechange only when the selection isn't collapsed since focusout will collapse and remove the selection
+			if (!editor.selection.isCollapsed() && !isSameElementPath(startElm) && editor.dom.isChildOf(startElm, editor.getBody())) {
 				editor.nodeChanged({selectionChange: true});
 			}
 		});

--- a/js/tinymce/classes/UndoManager.js
+++ b/js/tinymce/classes/UndoManager.js
@@ -39,7 +39,7 @@ define("tinymce/UndoManager", [
 		 * @return {String} HTML contents of the editor excluding some internal bogus elements.
 		 */
 		function getContent() {
-			var content = trim(editor.getContent({format: 'raw', no_events: 1}));
+			var content = editor.getContent({format: 'raw', no_events: 1});
 			var bogusAllRegExp = /<(\w+) [^>]*data-mce-bogus="all"[^>]*>/g;
 			var endTagIndex, index, matchLength, matches, shortEndedElements, schema = editor.schema;
 
@@ -61,7 +61,7 @@ define("tinymce/UndoManager", [
 				bogusAllRegExp.lastIndex = index - matchLength;
 			}
 
-			return content;
+			return trim(content);
 		}
 
 		function addNonTypingUndoLevel(e) {

--- a/js/tinymce/classes/dom/Serializer.js
+++ b/js/tinymce/classes/dom/Serializer.js
@@ -276,6 +276,18 @@ define("tinymce/dom/Serializer", [
 			 */
 			addAttributeFilter: htmlParser.addAttributeFilter,
 
+			serialize_without_validation: function(node, args) {
+				var htmlSerializer = new Serializer(settings, schema); // HTML serializer, NOT this one!
+				var body = node.cloneNode(true);
+
+				var parsedHTML = htmlParser.parse(body.innerHTML, args); // domSerializer parser
+				args.content = htmlSerializer.serialize(parsedHTML);
+
+				body = null;
+
+				return args.content;
+			},
+
 			/**
 			 * Serializes the specified browser DOM node into a HTML string.
 			 *

--- a/js/tinymce/classes/html/DomParser.js
+++ b/js/tinymce/classes/html/DomParser.js
@@ -142,7 +142,9 @@ define("tinymce/html/DomParser", [
 							continue;
 						}
 
-						node.wrap(self.filterNode(new Node('ul', 1)));
+						if (!settings.prevent_list_wrap) {
+							node.wrap(self.filterNode(new Node('ul', 1)));
+						}
 						continue;
 					}
 

--- a/js/tinymce/classes/html/DomParser.js
+++ b/js/tinymce/classes/html/DomParser.js
@@ -573,7 +573,13 @@ define("tinymce/html/DomParser", [
 									// Leave nodes that have a name like <a name="name">
 									if (!node.attributes.map.name && !node.attributes.map.id) {
 										tempNode = node.parent;
-										node.unwrap();
+
+										if (blockElements[node.name]) {
+											node.empty().remove();
+										} else {
+											node.unwrap();
+										}
+
 										node = tempNode;
 										return;
 									}

--- a/js/tinymce/classes/html/Node.js
+++ b/js/tinymce/classes/html/Node.js
@@ -327,6 +327,10 @@ define("tinymce/html/Node", [], function() {
 				node.remove();
 			}
 
+			if (!ref_node) {
+				ref_node = this;
+			}
+
 			parent = ref_node.parent || this;
 
 			if (before) {

--- a/js/tinymce/classes/html/Schema.js
+++ b/js/tinymce/classes/html/Schema.js
@@ -694,18 +694,18 @@ define("tinymce/html/Schema", [
 			// Remove these if they are empty by default
 			each(split('ol ul sub sup blockquote span font a table tbody tr strong em b i'), function(name) {
 				if (elements[name]) {
-					elements[name].removeEmpty = true;
+					elements[name].removeEmpty = false;
 				}
 			});
 
 			// Padd these by default
 			each(split('p h1 h2 h3 h4 h5 h6 th td pre div address caption'), function(name) {
-				elements[name].paddEmpty = true;
+				elements[name].paddEmpty = false;
 			});
 
 			// Remove these if they have no attributes
 			each(split('span'), function(name) {
-				elements[name].removeEmptyAttrs = true;
+				elements[name].removeEmptyAttrs = false;
 			});
 
 			// Remove these by default

--- a/js/tinymce/classes/ui/ColorBox.js
+++ b/js/tinymce/classes/ui/ColorBox.js
@@ -49,7 +49,11 @@ define("tinymce/ui/ColorBox", [
 			var elm = this.getEl().getElementsByTagName('i')[0];
 
 			if (elm) {
-				elm.style.background = value;
+				try {
+					elm.style.background = value;
+				} catch (ex) {
+					// Ignore
+				}
 			}
 		},
 

--- a/js/tinymce/classes/ui/ColorBox.js
+++ b/js/tinymce/classes/ui/ColorBox.js
@@ -32,7 +32,10 @@ define("tinymce/ui/ColorBox", [
 			var self = this;
 
 			settings.spellcheck = false;
-			settings.icon = 'none';
+
+			if (settings.onaction) {
+				settings.icon = 'none';
+			}
 
 			self._super(settings);
 
@@ -43,7 +46,11 @@ define("tinymce/ui/ColorBox", [
 		},
 
 		repaintColor: function(value) {
-			this.getEl().getElementsByTagName('i')[0].style.background = value;
+			var elm = this.getEl().getElementsByTagName('i')[0];
+
+			if (elm) {
+				elm.style.background = value;
+			}
 		},
 
 		value: function(value) {

--- a/js/tinymce/classes/util/Quirks.js
+++ b/js/tinymce/classes/util/Quirks.js
@@ -493,10 +493,11 @@ define("tinymce/util/Quirks", [
 
 				// Workaround for bug, http://bugs.webkit.org/show_bug.cgi?id=12250
 				// WebKit can't even do simple things like selecting an image
-				// Needs tobe the setBaseAndExtend or it will fail to select floated images
+				// Needs to be the setBaseAndExtend or it will fail to select floated images
 				if (/^(IMG|HR)$/.test(target.nodeName)) {
 					e.preventDefault();
 					selection.getSel().setBaseAndExtent(target, 0, target, 1);
+					editor.nodeChanged();
 				}
 
 				if (target.nodeName == 'A' && dom.hasClass(target, 'mce-item-anchor')) {

--- a/js/tinymce/plugins/noparsing/plugin.js
+++ b/js/tinymce/plugins/noparsing/plugin.js
@@ -1,0 +1,25 @@
+/**
+ * plugin.js
+ *
+ * Copyright, Shopify Inc.
+ * Released under LGPL License.
+ *
+ * License: http://www.tinymce.com/license
+ */
+
+/**
+ * No Parsing
+ *
+ * This plugin prevents HTML content from being parsed and reformatted by TinyMCE.
+ */
+tinymce.PluginManager.add('noparsing', function(editor) {
+
+  editor.on("BeforeSetContent", function(args) {
+    args.format = "unvalidated_html";
+  });
+
+  editor.on("BeforeGetContent", function(args) {
+    args.format = "unvalidated_html";
+  });
+
+});

--- a/js/tinymce/plugins/noparsing/plugin.js
+++ b/js/tinymce/plugins/noparsing/plugin.js
@@ -7,6 +7,8 @@
  * License: http://www.tinymce.com/license
  */
 
+/*global tinymce:true */
+
 /**
  * No Parsing
  *

--- a/js/tinymce/plugins/paste/classes/WordFilter.js
+++ b/js/tinymce/plugins/paste/classes/WordFilter.js
@@ -196,7 +196,7 @@ define("tinymce/pasteplugin/WordFilter", [
 						// Detect ordered lists 1., a. or ixv.
 						if (isNumericList(nodeText)) {
 							// Parse OL start number
-							var matches = /([0-9])\./.exec(nodeText);
+							var matches = /([0-9]+)\./.exec(nodeText);
 							var start = 1;
 							if (matches) {
 								start = parseInt(matches[1], 10);

--- a/js/tinymce/plugins/table/classes/Dialogs.js
+++ b/js/tinymce/plugins/table/classes/Dialogs.js
@@ -569,7 +569,7 @@ define("tinymce/tableplugin/Dialogs", [
 				editor.windowManager.open({
 					title: "Cell properties",
 					data: data,
-					items: generalCellForm,
+					body: generalCellForm,
 					onsubmit: onSubmitCellForm
 				});
 			}

--- a/js/tinymce/plugins/table/classes/Dialogs.js
+++ b/js/tinymce/plugins/table/classes/Dialogs.js
@@ -23,17 +23,21 @@ define("tinymce/tableplugin/Dialogs", [
 	return function(editor) {
 		var self = this;
 
-		function pickColorAction() {
-			var self = this, colorPickerCallback = editor.settings.color_picker_callback;
+		function createColorPickAction() {
+			var colorPickerCallback = editor.settings.color_picker_callback;
 
 			if (colorPickerCallback) {
-				colorPickerCallback.call(
-					editor,
-					function(value) {
-						self.value(value).fire('change');
-					},
-					self.value()
-				);
+				return function() {
+					var self = this;
+
+					colorPickerCallback.call(
+						editor,
+						function(value) {
+							self.value(value).fire('change');
+						},
+						self.value()
+					);
+				};
 			}
 		}
 
@@ -68,14 +72,14 @@ define("tinymce/tableplugin/Dialogs", [
 								label: 'Border color',
 								type: 'colorbox',
 								name: 'borderColor',
-								onaction: pickColorAction
+								onaction: createColorPickAction()
 							},
 
 							{
 								label: 'Background color',
 								type: 'colorbox',
 								name: 'backgroundColor',
-								onaction: pickColorAction
+								onaction: createColorPickAction()
 							}
 						]
 					}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
 		"jscs": ">= 1.4.5"
 	},
 	"scripts": {
-		"test": "jake jscs jshint eslint minify less phantomjs-tests"
+		"test": "jake minify less phantomjs-tests"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,4 @@
-[![Circle CI](https://circleci.com/gh/Shopify/tinymce/tree/master.png?style=badge)](https://circleci.com/gh/Shopify/tinymce/tree/master)
-
-TinyMCE for Shopify
+TinyMCE for Shopify [![Circle CI](https://circleci.com/gh/Shopify/tinymce/tree/master.png?style=badge&circle-token=2c4ac059228c6f333b398302d18f2c05d09638a9)](https://circleci.com/gh/Shopify/tinymce/tree/master)
 ==========================================
 This is a fork of [https://github.com/tinymce/tinymce](TinyMCE) customized to suit Shopify's specific needs.
 

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,6 @@
-TinyMCE - The JavaScript Rich Text editor
+TinyMCE for Shopify 
 ==========================================
+This is a fork of [https://github.com/tinymce/tinymce](TinyMCE) customized to suit Shopify's specific needs. 
 
 Building TinyMCE
 -----------------

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
-TinyMCE for Shopify 
+[![Circle CI](https://circleci.com/gh/Shopify/tinymce/tree/master.png?style=badge)](https://circleci.com/gh/Shopify/tinymce/tree/master)
+
+TinyMCE for Shopify
 ==========================================
-This is a fork of [https://github.com/tinymce/tinymce](TinyMCE) customized to suit Shopify's specific needs. 
+This is a fork of [https://github.com/tinymce/tinymce](TinyMCE) customized to suit Shopify's specific needs.
 
 Building TinyMCE
 -----------------

--- a/tests/js/init.js
+++ b/tests/js/init.js
@@ -58,9 +58,12 @@
 		window.global_test_results = results;
 	});
 
-	/* Custom skip override addition */
+	/* Custom QUnit skip functionality */
 	QUnit.test.skip = function( testName, expected, callback, async ) {
-		console.log('Test skipped:', testName);
+		console.log('Test skipped: ' + QUnit.config.currentModule + ': ' + testName);
+		if (callback) {
+			callback();
+		}
 	};
 
 	window.module = function(name, settings) {

--- a/tests/js/init.js
+++ b/tests/js/init.js
@@ -58,6 +58,11 @@
 		window.global_test_results = results;
 	});
 
+	/* Custom skip override addition */
+	QUnit.test.skip = function( testName, expected, callback, async ) {
+		console.log('Test skipped:', testName);
+	};
+
 	window.module = function(name, settings) {
 		settings = settings || {};
 

--- a/tests/plugins/autolink.js
+++ b/tests/plugins/autolink.js
@@ -70,11 +70,11 @@
 	});
 
 	test("Urls ended with new line", function() {
-		equal(typeNewlineURL('http://www.domain.com'), '<p><a href="http://www.domain.com">http://www.domain.com</a></p><p>&nbsp;</p>');
-		equal(typeNewlineURL('https://www.domain.com'), '<p><a href="https://www.domain.com">https://www.domain.com</a></p><p>&nbsp;</p>');
-		equal(typeNewlineURL('ssh://www.domain.com'), '<p><a href="ssh://www.domain.com">ssh://www.domain.com</a></p><p>&nbsp;</p>');
-		equal(typeNewlineURL('ftp://www.domain.com'), '<p><a href="ftp://www.domain.com">ftp://www.domain.com</a></p><p>&nbsp;</p>');
-		equal(typeNewlineURL('www.domain.com'), '<p><a href="http://www.domain.com">www.domain.com</a></p><p>&nbsp;</p>');
-		equal(typeNewlineURL('www.domain.com.'), '<p><a href="http://www.domain.com">www.domain.com</a>.</p><p>&nbsp;</p>');
+		equal(typeNewlineURL('http://www.domain.com'), '<p><a href="http://www.domain.com">http://www.domain.com</a></p><p></p>');
+		equal(typeNewlineURL('https://www.domain.com'), '<p><a href="https://www.domain.com">https://www.domain.com</a></p><p></p>');
+		equal(typeNewlineURL('ssh://www.domain.com'), '<p><a href="ssh://www.domain.com">ssh://www.domain.com</a></p><p></p>');
+		equal(typeNewlineURL('ftp://www.domain.com'), '<p><a href="ftp://www.domain.com">ftp://www.domain.com</a></p><p></p>');
+		equal(typeNewlineURL('www.domain.com'), '<p><a href="http://www.domain.com">www.domain.com</a></p><p></p>');
+		equal(typeNewlineURL('www.domain.com.'), '<p><a href="http://www.domain.com">www.domain.com</a>.</p><p></p>');
 	});
 })();

--- a/tests/plugins/lists.js
+++ b/tests/plugins/lists.js
@@ -71,7 +71,7 @@ test('Apply UL list to single P', function() {
 	Utils.setSelection('p', 0);
 	execCommand('InsertUnorderedList');
 
-	equal(editor.getContent(),'<ul><li>a</li></ul>');
+	equal(editor.getContent(), '<ul><li>a</li></ul>');
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
@@ -118,7 +118,7 @@ test('Apply OL list to single P', function() {
 	Utils.setSelection('p', 0);
 	execCommand('InsertOrderedList');
 
-	equal(editor.getContent(),'<ol><li>a</li></ol>');
+	equal(editor.getContent(), '<ol><li>a</li></ol>');
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
@@ -359,7 +359,7 @@ test('Apply UL list to single text line', function() {
 	Utils.setSelection('body', 0);
 	execCommand('InsertUnorderedList');
 
-	equal(editor.getContent(),'<ul><li>a</li></ul>');
+	equal(editor.getContent(), '<ul><li>a</li></ul>');
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
@@ -374,7 +374,7 @@ test('Apply UL list to single text line with BR', function() {
 	Utils.setSelection('body', 0);
 	execCommand('InsertUnorderedList');
 
-	equal(editor.getContent(),'<ul><li>a</li></ul>');
+	equal(editor.getContent(), '<ul><li>a</li></ul>');
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
@@ -1633,6 +1633,75 @@ test('Backspace at beginning of middle LI in UL inside UL', function() {
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
+test('Backspace at beginning of LI with empty LI above in UL', function() {
+	editor.getBody().innerHTML = trimBrs(
+		'<ul>' +
+			'<li>a</li>' +
+			'<li></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li:nth-child(3)', 0);
+	editor.plugins.lists.backspaceDelete();
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'b');
+});
+
+test('Backspace at beginning of LI with BR padded empty LI above in UL', function() {
+	editor.getBody().innerHTML = (
+		'<ul>' +
+			'<li>a</li>' +
+			'<li><br></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li:nth-child(3)', 0);
+	editor.plugins.lists.backspaceDelete();
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'b');
+});
+
+test('Backspace at beginning of LI with empty LI with STRING and BR above in UL', function() {
+	editor.getBody().innerHTML = (
+		'<ul>' +
+			'<li>a</li>' +
+			'<li><strong><br></strong></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li:nth-child(3)', 0);
+	editor.plugins.lists.backspaceDelete();
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'b');
+});
+
 // Delete
 
 test('Delete at end of single LI in UL', function() {
@@ -1759,6 +1828,75 @@ test('Delete at end of middle LI in UL inside UL', function() {
 	equal(editor.selection.getNode().nodeName, 'LI');
 });
 
+test('Delete at end of LI before empty LI', function() {
+	editor.getBody().innerHTML = (
+		'<ul>' +
+			'<li>a</li>' +
+			'<li></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li', 1);
+	editor.plugins.lists.backspaceDelete(true);
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'a');
+});
+
+test('Delete at end of LI before BR padded empty LI', function() {
+	editor.getBody().innerHTML = (
+		'<ul>' +
+			'<li>a</li>' +
+			'<li><br></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li', 1);
+	editor.plugins.lists.backspaceDelete(true);
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'a');
+});
+
+test('Delete at end of LI before empty LI with STRONG', function() {
+	editor.getBody().innerHTML = (
+		'<ul>' +
+			'<li>a</li>' +
+			'<li><strong><br></strong></li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	editor.focus();
+	Utils.setSelection('li', 1);
+	editor.plugins.lists.backspaceDelete(true);
+
+	equal(editor.getContent(),
+		'<ul>' +
+			'<li>a</li>' +
+			'<li>b</li>' +
+		'</ul>'
+	);
+
+	equal(editor.selection.getNode().innerHTML, 'a');
+});
+
 test('Remove UL in inline body element contained in LI', function() {
 	inlineEditor.setContent('<ul><li>a</li></ul>');
 	inlineEditor.selection.setCursorLocation();
@@ -1805,7 +1943,7 @@ test('Apply OL list to single P', function() {
 	Utils.setSelection('p', 0);
 	execCommand('InsertDefinitionList');
 
-	equal(editor.getContent(),'<dl><dt>a</dt></dl>');
+	equal(editor.getContent(), '<dl><dt>a</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 

--- a/tests/plugins/paste.js
+++ b/tests/plugins/paste.js
@@ -730,7 +730,7 @@ if (tinymce.Env.webkit) {
 			)
 		});
 
-		equal(editor.getContent(), '<p style="color: #ff0000;"><span>a</span><span>b</span><span>c</span></p></p>');
+		equal(editor.getContent(), '<p style="color: #ff0000;"><span>a</span><span>b</span><span>c</span></p>');
 	});
 
 	test('paste webkit remove runtime styles (color) in the same (color) (rgb)', function() {

--- a/tests/plugins/paste.js
+++ b/tests/plugins/paste.js
@@ -693,13 +693,15 @@ if (tinymce.Env.webkit) {
 		equal(editor.getContent(), '<p><span style=\"color: red; font-style: italic; text-indent: 10px;\">Test</span></p>');
 	});
 
+	/* Modified to keep with https://github.com/Shopify/shopify/pull/8208 */
 	test('paste webkit remove runtime styles (none)', function() {
 		editor.settings.paste_webkit_styles = 'none';
 		editor.setContent('');
 		editor.execCommand('mceInsertClipboardContent', false, {content: '<span style="color: red; font-style: italic; text-indent: 10px">Test</span>'});
-		equal(editor.getContent(), '<p>Test</p>');
+		equal(editor.getContent(), '<p><span>Test</span></p>');
 	});
 
+	/* Modified to keep with https://github.com/Shopify/shopify/pull/8208 */
 	test('paste webkit remove runtime styles (color) in the same (color) (named)', function() {
 		editor.settings.paste_webkit_styles = 'color';
 
@@ -713,7 +715,7 @@ if (tinymce.Env.webkit) {
 			)
 		});
 
-		equal(editor.getContent(), '<p style="color: red;">ab</p>');
+		equal(editor.getContent(), '<p style="color: red;"><span>a</span><span>b</span></p>');
 	});
 
 	test('paste webkit remove runtime styles (color) in the same (color) (hex)', function() {
@@ -728,7 +730,7 @@ if (tinymce.Env.webkit) {
 			)
 		});
 
-		equal(editor.getContent(), '<p style="color: #ff0000;">abc</p>');
+		equal(editor.getContent(), '<p style="color: #ff0000;"><span>a</span><span>b</span><span>c</span></p></p>');
 	});
 
 	test('paste webkit remove runtime styles (color) in the same (color) (rgb)', function() {
@@ -743,6 +745,6 @@ if (tinymce.Env.webkit) {
 			)
 		});
 
-		equal(editor.getContent(), '<p style="color: #ff0000;">abc</p>');
+		equal(editor.getContent(), '<p style="color: #ff0000;"><span>a</span><span>b</span><span>c</span></p>');
 	});
 }

--- a/tests/plugins/paste.js
+++ b/tests/plugins/paste.js
@@ -356,6 +356,22 @@ test('paste nested (OL) word list', function() {
 	);
 });
 
+test("Paste list start index", function() {
+	editor.settings.paste_merge_formats = true;
+
+	editor.setContent('');
+
+	editor.execCommand('mceInsertClipboardContent', false, {
+		content: (
+			'<p class=MsoListParagraphCxSpMiddle style="text-indent:-18.0pt;mso-list:l0 level1 lfo1">' +
+			'<![if !supportLists]><span style="mso-fareast-font-family:Calibri;mso-fareast-theme-font:minor-latin;' +
+			'mso-bidi-font-family:Calibri;mso-bidi-theme-font:minor-latin"><span style="mso-list:Ignore">10.' +
+			'<span style="font:7.0pt Times>&nbsp;&nbsp;</span></span></span><![endif]>J<o:p></o:p></p>'
+		)
+	});
+	equal(editor.getContent(), '<ol start="10"><li>J</li></ol>');
+})
+
 test("Paste paste_merge_formats: true", function() {
 	editor.settings.paste_merge_formats = true;
 

--- a/tests/plugins/table.js
+++ b/tests/plugins/table.js
@@ -163,7 +163,7 @@
 
 		equal(
 			cleanTableHtml(editor.getContent()),
-			'<table><caption>&nbsp;</caption><tbody><tr><td>x</td></tr></tbody></table>'
+			'<table><caption></caption><tbody><tr><td>x</td></tr></tbody></table>'
 		);
 	});
 
@@ -382,28 +382,28 @@
 		editor.setContent('<table><tr><td>1</td></tr><tr><td>2</td></tr></table>');
 		Utils.setSelection('td', 0);
 		editor.execCommand('mceTableInsertColAfter');
-		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>1</td><td>&nbsp;</td></tr><tr><td>2</td><td>&nbsp;</td></tr></tbody></table>');
+		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>1</td><td></td></tr><tr><td>2</td><td></td></tr></tbody></table>');
 	});
 
 	test("mceTableInsertColBefore command", function() {
 		editor.setContent('<table><tr><td>1</td></tr><tr><td>2</td></tr></table>');
 		Utils.setSelection('td', 0);
 		editor.execCommand('mceTableInsertColBefore');
-		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>&nbsp;</td><td>1</td></tr><tr><td>&nbsp;</td><td>2</td></tr></tbody></table>');
+		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td></td><td>1</td></tr><tr><td></td><td>2</td></tr></tbody></table>');
 	});
 
 	test("mceTableInsertRowAfter command", function() {
 		editor.setContent('<table><tr><td>1</td><td>2</td></tr></table>');
 		Utils.setSelection('td', 0);
 		editor.execCommand('mceTableInsertRowAfter');
-		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>1</td><td>2</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table>');
+		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>1</td><td>2</td></tr><tr><td></td><td></td></tr></tbody></table>');
 	});
 
 	test("mceTableInsertRowBefore command", function() {
 		editor.setContent('<table><tr><td>1</td><td>2</td></tr></table>');
 		Utils.setSelection('td', 0);
 		editor.execCommand('mceTableInsertRowBefore');
-		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>1</td><td>2</td></tr></tbody></table>');
+		equal(cleanTableHtml(editor.getContent()), '<table><tbody><tr><td></td><td></td></tr><tr><td>1</td><td>2</td></tr></tbody></table>');
 	});
 
 	test("mceTableMergeCells command with cell selection", function() {
@@ -419,7 +419,7 @@
 		editor.execCommand('mceTableSplitCells');
 		equal(
 			cleanTableHtml(editor.getContent()),
-			'<table><tbody><tr><td>12</td><td>&nbsp;</td></tr></tbody></table>'
+			'<table><tbody><tr><td>12</td><td></td></tr></tbody></table>'
 		);
 	});
 
@@ -443,7 +443,7 @@
 		equal(editor.selection.getStart(true).nodeName, 'TD');
 		equal(
 			editor.getContent(),
-			'<table><tbody><tr><td>A1</td><td>A2</td></tr><tr><td>B1</td><td>B2</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table><p>x</p>'
+			'<table><tbody><tr><td>A1</td><td>A2</td></tr><tr><td>B1</td><td>B2</td></tr><tr><td></td><td></td></tr></tbody></table><p>x</p>'
 		);
 	});
 })();

--- a/tests/plugins/textpattern.js
+++ b/tests/plugins/textpattern.js
@@ -61,7 +61,7 @@
 
 		equal(
 			editor.getContent(),
-			'<p><strong>abc</strong></p><p>&nbsp;</p>'
+			'<p><strong>abc</strong></p><p></p>'
 		);
 	});
 
@@ -72,7 +72,7 @@
 
 		equal(
 			editor.getContent(),
-			'<h1>abc</h1><p>&nbsp;</p>'
+			'<h1>abc</h1><p></p>'
 		);
 	});
 

--- a/tests/plugins/textpattern.js
+++ b/tests/plugins/textpattern.js
@@ -61,7 +61,7 @@
 
 		equal(
 			editor.getContent(),
-			'<p><strong>abc</strong></p><p></p>'
+			'<p><strong>abc</strong></p><p><strong></strong></p>'
 		);
 	});
 

--- a/tests/tinymce/Editor.js
+++ b/tests/tinymce/Editor.js
@@ -218,7 +218,7 @@ test('setContent with comment bug #4409', function() {
 	editor.settings.disable_nodechange = false;
 	editor.nodeChanged();
 	editor.settings.disable_nodechange = true;
-	equal(editor.getContent(), "<!-- x --><p>\u00a0</p>");
+	equal(editor.getContent(), "<!-- x --><p></p>");
 });
 
 test('custom elements', function() {

--- a/tests/tinymce/EnterKey.js
+++ b/tests/tinymce/EnterKey.js
@@ -329,7 +329,6 @@ test('Enter inside empty li in the middle of ol', function() {
 });
 
 // Nested lists in LI elements
-
 test('Enter inside empty LI in beginning of OL in LI', function() {
 	editor.getBody().innerHTML = Utils.trimBrsOnIE(
 		'<ol>' +
@@ -384,7 +383,7 @@ test('Enter inside empty LI in middle of OL in LI', function() {
 					'<li>a</li>' +
 				'</ol>' +
 			'</li>' +
-			'<li>' +
+			'<li>\u00A0' +
 				'<ol>' +
 					'<li>b</li>' +
 				'</ol>' +
@@ -451,7 +450,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		equal(editor.getContent(),
 			'<ol>' +
 				'<li>a</li>' +
-				'<li>' +
+				'<li>\u00A0' +
 					'<ul>' +
 						'<li>b</li>' +
 						'<li>c</li>' +
@@ -556,7 +555,7 @@ test('Enter at beginning of first DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
 	Utils.setSelection('dt', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt></dt><dt>a</dt></dl>');
+	equal(editor.getContent(),'<dl><dt>\u00A0</dt><dt>a</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -564,7 +563,7 @@ test('Enter at beginning of first DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
 	Utils.setSelection('dd', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd></dd><dd>a</dd></dl>');
+	equal(editor.getContent(),'<dl><dd>\u00A0</dd><dd>a</dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 
@@ -572,7 +571,7 @@ test('Enter at beginning of middle DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt><dt>b</dt><dt>c</dt></dl>';
 	Utils.setSelection('dt:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>a</dt><dt></dt><dt>b</dt><dt>c</dt></dl>');
+	equal(editor.getContent(),'<dl><dt>a</dt><dt>\u00A0</dt><dt>b</dt><dt>c</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -580,7 +579,7 @@ test('Enter at beginning of middle DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd><dd>b</dd><dd>c</dd></dl>';
 	Utils.setSelection('dd:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>a</dd><dd></dd><dd>b</dd><dd>c</dd></dl>');
+	equal(editor.getContent(),'<dl><dd>a</dd><dd>\u00A0</dd><dd>b</dd><dd>c</dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 
@@ -588,7 +587,7 @@ test('Enter at end of last DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
 	Utils.setSelection('dt', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>a</dt><dt></dt></dl>');
+	equal(editor.getContent(),'<dl><dt>a</dt><dt>\u00A0</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -596,7 +595,7 @@ test('Enter at end of last DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
 	Utils.setSelection('dd', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>a</dd><dd></dd></dl>');
+	equal(editor.getContent(),'<dl><dd>a</dd><dd>\u00A0</dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 

--- a/tests/tinymce/EnterKey.js
+++ b/tests/tinymce/EnterKey.js
@@ -35,7 +35,7 @@ test('Enter at end of H1', function() {
 	editor.setContent('<h1>abc</h1>');
 	Utils.setSelection('h1', 3);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<h1>abc</h1><p>\u00a0</p>');
+	equal(editor.getContent(),'<h1>abc</h1><p></p>');
 	equal(editor.selection.getRng(true).startContainer.nodeName, 'P');
 });
 
@@ -60,7 +60,7 @@ test('Enter before first IMG in P', function() {
 	editor.setContent('<p><img alt="" src="about:blank" /></p>');
 	editor.selection.setCursorLocation(editor.getBody().firstChild, 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><p><img src="about:blank" alt="" /></p>');
+	equal(editor.getContent(),'<p></p><p><img src="about:blank" alt="" /></p>');
 });
 
 test('Enter before last IMG in P with text', function() {
@@ -87,7 +87,7 @@ test('Enter after last IMG in P', function() {
 	editor.setContent('<p>abc<img alt="" src="about:blank" /></p>');
 	editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>abc<img src="about:blank" alt="" /></p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p>abc<img src="about:blank" alt="" /></p><p></p>');
 });
 
 test('Enter before last INPUT in P with text', function() {
@@ -114,14 +114,14 @@ test('Enter after last INPUT in P', function() {
 	editor.setContent('<p>abc<input type="text" /></p>');
 	editor.selection.setCursorLocation(editor.getBody().firstChild, 2);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>abc<input type="text" /></p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p>abc<input type="text" /></p><p></p>');
 });
 
 test('Enter at end of P', function() {
 	editor.setContent('<p>abc</p>');
 	Utils.setSelection('p', 3);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>abc</p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p>abc</p><p></p>');
 	equal(editor.selection.getRng(true).startContainer.nodeName, 'P');
 });
 
@@ -177,7 +177,7 @@ test('Enter at beginning of P', function() {
 	editor.setContent('<p>abc</p>');
 	Utils.setSelection('p', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><p>abc</p>');
+	equal(editor.getContent(),'<p></p><p>abc</p>');
 	equal(editor.selection.getRng(true).startContainer.nodeValue, 'abc');
 });
 
@@ -201,7 +201,7 @@ test('Enter at end of H1 in HGROUP', function() {
 	editor.setContent('<hgroup><h1>abc</h1></hgroup>');
 	Utils.setSelection('h1', 3);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<hgroup><h1>abc</h1><h1>\u00a0</h1></hgroup>');
+	equal(editor.getContent(),'<hgroup><h1>abc</h1><h1></h1></hgroup>');
 	equal(editor.selection.getRng(true).startContainer.nodeName, 'H1');
 });
 
@@ -233,7 +233,7 @@ test('Enter inside at beginning of text node in body', function() {
 	editor.getBody().innerHTML = 'abcd';
 	Utils.setSelection('body', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><p>abcd</p>');
+	equal(editor.getContent(),'<p></p><p>abcd</p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -241,7 +241,7 @@ test('Enter inside at end of text node in body', function() {
 	editor.getBody().innerHTML = 'abcd';
 	Utils.setSelection('body', 4);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>abcd</p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p>abcd</p><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -249,7 +249,7 @@ test('Enter inside empty body', function() {
 	editor.getBody().innerHTML = '';
 	Utils.setSelection('body', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p></p><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -257,7 +257,7 @@ test('Enter inside empty li in beginning of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li></li><li>a</li></ol>': '<ol><li><br></li><li>a</li></ol>';
 	Utils.setSelection('li', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><ol><li>a</li></ol>');
+	equal(editor.getContent(),'<p></p><ol><li>a</li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -265,7 +265,7 @@ test('Enter inside empty li at the end of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li>a</li><li></li></ol>': '<ol><li>a</li><li><br></li></ol>';
 	Utils.setSelection('li:last', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<ol><li>a</li></ol><p>\u00a0</p>');
+	equal(editor.getContent(),'<ol><li>a</li></ol><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -273,7 +273,7 @@ test('Shift+Enter inside empty li in the middle of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li>a</li><li></li><li>b</li></ol>':  '<ol><li>a</li><li><br></li><li>b</li></ol>';
 	Utils.setSelection('li:nth-child(2)', 0);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<ol><li>a</li></ol><p>\u00a0</p><ol><li>b</li></ol>');
+	equal(editor.getContent(),'<ol><li>a</li></ol><p></p><ol><li>b</li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -281,7 +281,7 @@ test('Shift+Enter inside empty li in beginning of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li></li><li>a</li></ol>': '<ol><li><br></li><li>a</li></ol>';
 	Utils.setSelection('li', 0);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<p>\u00a0</p><ol><li>a</li></ol>');
+	equal(editor.getContent(),'<p></p><ol><li>a</li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -289,7 +289,7 @@ test('Shift+Enter inside empty li at the end of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li>a</li><li></li></ol>': '<ol><li>a</li><li><br></li></ol>';
 	Utils.setSelection('li:last', 0);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<ol><li>a</li></ol><p>\u00a0</p>');
+	equal(editor.getContent(),'<ol><li>a</li></ol><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -324,7 +324,7 @@ test('Enter inside empty li in the middle of ol', function() {
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<ol><li>a</li><li></li><li>b</li></ol>':  '<ol><li>a</li><li><br></li><li>b</li></ol>';
 	Utils.setSelection('li:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<ol><li>a</li></ol><p>\u00a0</p><ol><li>b</li></ol>');
+	equal(editor.getContent(),'<ol><li>a</li></ol><p></p><ol><li>b</li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -384,7 +384,7 @@ test('Enter inside empty LI in middle of OL in LI', function() {
 					'<li>a</li>' +
 				'</ol>' +
 			'</li>' +
-			'<li>\u00a0' +
+			'<li>' +
 				'<ol>' +
 					'<li>b</li>' +
 				'</ol>' +
@@ -451,7 +451,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		equal(editor.getContent(),
 			'<ol>' +
 				'<li>a</li>' +
-				'<li>\u00a0' +
+				'<li>' +
 					'<ul>' +
 						'<li>b</li>' +
 						'<li>c</li>' +
@@ -556,7 +556,7 @@ test('Enter at beginning of first DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
 	Utils.setSelection('dt', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>\u00a0</dt><dt>a</dt></dl>');
+	equal(editor.getContent(),'<dl><dt></dt><dt>a</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -564,7 +564,7 @@ test('Enter at beginning of first DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
 	Utils.setSelection('dd', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>\u00a0</dd><dd>a</dd></dl>');
+	equal(editor.getContent(),'<dl><dd></dd><dd>a</dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 
@@ -572,7 +572,7 @@ test('Enter at beginning of middle DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt><dt>b</dt><dt>c</dt></dl>';
 	Utils.setSelection('dt:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>a</dt><dt>\u00a0</dt><dt>b</dt><dt>c</dt></dl>');
+	equal(editor.getContent(),'<dl><dt>a</dt><dt></dt><dt>b</dt><dt>c</dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -580,7 +580,7 @@ test('Enter at beginning of middle DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd><dd>b</dd><dd>c</dd></dl>';
 	Utils.setSelection('dd:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>a</dd><dd>\u00a0</dd><dd>b</dd><dd>c</dd></dl>');
+	equal(editor.getContent(),'<dl><dd>a</dd><dd></dd><dd>b</dd><dd>c</dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 
@@ -588,7 +588,7 @@ test('Enter at end of last DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt></dl>';
 	Utils.setSelection('dt', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>a</dt><dt>\u00a0</dt></dl>');
+	equal(editor.getContent(),'<dl><dt>a</dt><dt></dt></dl>');
 	equal(editor.selection.getNode().nodeName, 'DT');
 });
 
@@ -596,7 +596,7 @@ test('Enter at end of last DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd></dl>';
 	Utils.setSelection('dd', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>a</dd><dd>\u00a0</dd></dl>');
+	equal(editor.getContent(),'<dl><dd>a</dd><dd></dd></dl>');
 	equal(editor.selection.getNode().nodeName, 'DD');
 });
 
@@ -604,7 +604,7 @@ test('Enter at end of last empty DT inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dt>a</dt><dt></dt></dl>';
 	Utils.setSelection('dt:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dt>a</dt></dl><p>\u00a0</p>');
+	equal(editor.getContent(),'<dl><dt>a</dt></dl><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -612,7 +612,7 @@ test('Enter at end of last empty DD inside DL', function() {
 	editor.getBody().innerHTML = '<dl><dd>a</dd><dd></dd></dl>';
 	Utils.setSelection('dd:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<dl><dd>a</dd></dl><p>\u00a0</p>');
+	equal(editor.getContent(),'<dl><dd>a</dd></dl><p></p>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -674,7 +674,7 @@ test('Ctrl+Enter at beginning of P inside LI', function() {
 	editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
 	Utils.setSelection('p', 0);
 	Utils.pressEnter({ctrlKey: true});
-	equal(editor.getContent(),'<ol><li><p>\u00a0</p><p>abcd</p></li></ol>');
+	equal(editor.getContent(),'<ol><li><p></p><p>abcd</p></li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -690,7 +690,7 @@ test('Ctrl+Enter at end of P inside LI', function() {
 	editor.getBody().innerHTML = '<ol><li><p>abcd</p></li></ol>';
 	Utils.setSelection('p', 4);
 	Utils.pressEnter({ctrlKey: true});
-	equal(editor.getContent(),'<ol><li><p>abcd</p><p>\u00a0</p></li></ol>');
+	equal(editor.getContent(),'<ol><li><p>abcd</p><p></p></li></ol>');
 	equal(editor.selection.getNode().nodeName, 'P');
 });
 
@@ -743,7 +743,7 @@ test('Enter in empty P at the end of a blockquote and end_container_on_empty_blo
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<blockquote><p>abc</p><p></p></blockquote>': '<blockquote><p>abc</p><p><br></p></blockquote>';
 	Utils.setSelection('p:last', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<blockquote><p>abc</p></blockquote><p>\u00a0</p>');
+	equal(editor.getContent(),'<blockquote><p>abc</p></blockquote><p></p>');
 });
 
 test('Enter in empty P at the beginning of a blockquote and end_container_on_empty_block: true', function() {
@@ -751,7 +751,7 @@ test('Enter in empty P at the beginning of a blockquote and end_container_on_emp
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<blockquote><p></p><p>abc</p></blockquote>': '<blockquote><p><br></p><p>abc</p></blockquote>';
 	Utils.setSelection('p', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><blockquote><p>abc</p></blockquote>');
+	equal(editor.getContent(),'<p></p><blockquote><p>abc</p></blockquote>');
 });
 
 test('Enter in empty P at in the middle of a blockquote and end_container_on_empty_block: true', function() {
@@ -759,7 +759,7 @@ test('Enter in empty P at in the middle of a blockquote and end_container_on_emp
 	editor.getBody().innerHTML = (tinymce.isIE && tinymce.Env.ie < 11) ? '<blockquote><p>abc</p><p></p><p>123</p></blockquote>': '<blockquote><p>abc</p><p><br></p><p>123</p></blockquote>';
 	Utils.setSelection('p:nth-child(2)', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<blockquote><p>abc</p></blockquote><p>\u00a0</p><blockquote><p>123</p></blockquote>');
+	equal(editor.getContent(),'<blockquote><p>abc</p></blockquote><p></p><blockquote><p>123</p></blockquote>');
 });
 
 test('Enter inside empty P with empty P siblings', function() {
@@ -767,7 +767,7 @@ test('Enter inside empty P with empty P siblings', function() {
 	editor.getBody().innerHTML = '<p></p><p></p><p>X</p>';
 	Utils.setSelection('p', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p>\u00a0</p><p>\u00a0</p><p>\u00a0</p><p>X</p>');
+	equal(editor.getContent(),'<p></p><p></p><p></p><p>X</p>');
 });
 
 test('Enter at end of H1 with forced_root_block_attrs', function() {
@@ -775,7 +775,7 @@ test('Enter at end of H1 with forced_root_block_attrs', function() {
 	editor.getBody().innerHTML = '<h1>a</h1>';
 	Utils.setSelection('h1', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<h1>a</h1><p class="class1">\u00a0</p>');
+	equal(editor.getContent(),'<h1>a</h1><p class="class1"></p>');
 });
 
 test('Shift+Enter at beginning of P', function() {
@@ -839,7 +839,7 @@ test('Enter in beginning of PRE and br_in_pre: false', function() {
 	editor.getBody().innerHTML = '<pre>abc</pre>';
 	Utils.setSelection('pre', 0);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<pre>\u00a0</pre><pre>abc</pre>');
+	equal(editor.getContent(),'<pre></pre><pre>abc</pre>');
 });
 
 test('Enter in the middle of PRE and br_in_pre: false', function() {
@@ -855,14 +855,14 @@ test('Enter at the end of PRE and br_in_pre: false', function() {
 	editor.getBody().innerHTML = '<pre>abcd</pre>';
 	Utils.setSelection('pre', 4);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<pre>abcd</pre><p>\u00a0</p>');
+	equal(editor.getContent(),'<pre>abcd</pre><p></p>');
 });
 
 test('Shift+Enter in beginning of PRE', function() {
 	editor.getBody().innerHTML = '<pre>abc</pre>';
 	Utils.setSelection('pre', 0);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<pre>\u00a0</pre><pre>abc</pre>');
+	equal(editor.getContent(),'<pre></pre><pre>abc</pre>');
 });
 
 test('Shift+Enter in the middle of PRE', function() {
@@ -876,7 +876,7 @@ test('Shift+Enter at the end of PRE', function() {
 	editor.getBody().innerHTML = '<pre>abcd</pre>';
 	Utils.setSelection('pre', 4);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<pre>abcd</pre><p>\u00a0</p>');
+	equal(editor.getContent(),'<pre>abcd</pre><p></p>');
 });
 
 test('Shift+Enter in beginning of P with forced_root_block set to false', function() {
@@ -884,7 +884,7 @@ test('Shift+Enter in beginning of P with forced_root_block set to false', functi
 	editor.getBody().innerHTML = '<p>abc</p>';
 	Utils.setSelection('p', 0);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<p>\u00a0</p><p>abc</p>');
+	equal(editor.getContent(),'<p></p><p>abc</p>');
 });
 
 test('Shift+Enter in middle of P with forced_root_block set to false', function() {
@@ -900,7 +900,7 @@ test('Shift+Enter at the end of P with forced_root_block set to false', function
 	editor.getBody().innerHTML = '<p>abc</p>';
 	Utils.setSelection('p', 3);
 	Utils.pressEnter({shiftKey: true});
-	equal(editor.getContent(),'<p>abc</p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p>abc</p><p></p>');
 });
 
 test('Shift+Enter in body with forced_root_block set to false', function() {
@@ -919,7 +919,7 @@ test('Enter at the end of DIV layer', function() {
 	editor.setContent('<div style="position: absolute; top: 1px; left: 2px;">abcd</div>');
 	Utils.setSelection('div', 4);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<div style="position: absolute; top: 1px; left: 2px;"><p>abcd</p><p>\u00a0</p></div>');
+	equal(editor.getContent(),'<div style="position: absolute; top: 1px; left: 2px;"><p>abcd</p><p></p></div>');
 });
 
 test('Enter in div inside contentEditable:false div', function() {
@@ -970,7 +970,7 @@ test('Enter at end of text in a span inside a P and keep_styles: false', functio
 	editor.getBody().innerHTML = '<p><em><span style="font-size: 13px;">X</span></em></p>';
 	Utils.setSelection('span', 1);
 	Utils.pressEnter();
-	equal(editor.getContent(),'<p><em><span style="font-size: 13px;">X</span></em></p><p>\u00a0</p>');
+	equal(editor.getContent(),'<p><em><span style="font-size: 13px;">X</span></em></p><p></p>');
 });
 
 test('Shift+enter in LI when forced_root_block: false', function() {
@@ -1012,7 +1012,7 @@ if (!tinymce.Env.ie || tinymce.Env.ie > 8) {
 		rng.setEndBefore(editor.dom.select('br')[0]);
 		editor.selection.setRng(rng);
 		Utils.pressEnter();
-		equal(editor.getContent(),'<div>a<span>b</span>c</div><p>\u00a0</p><p>\u00a0</p><div>d</div>');
+		equal(editor.getContent(),'<div>a<span>b</span>c</div><p></p><p></p><div>d</div>');
 	});
 }
 
@@ -1027,7 +1027,7 @@ if (window.getSelection) {
 		editor.selection.setRng(rng);
 
 		Utils.pressEnter();
-		equal(editor.getContent(),'<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p>');
+		equal(editor.getContent(),'<table><tbody><tr><td>x</td></tr></tbody></table><p></p>');
 	});
 
 	test('Enter before table element', function() {
@@ -1039,7 +1039,7 @@ if (window.getSelection) {
 		editor.selection.setRng(rng);
 
 		Utils.pressEnter();
-		equal(editor.getContent(),'<p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
+		equal(editor.getContent(),'<p></p><table><tbody><tr><td>x</td></tr></tbody></table>');
 	});
 
 	test('Enter behind table followed by a p', function() {
@@ -1051,7 +1051,7 @@ if (window.getSelection) {
 		editor.selection.setRng(rng);
 
 		Utils.pressEnter();
-		equal(editor.getContent(),'<table><tbody><tr><td>x</td></tr></tbody></table><p>\u00a0</p><p>x</p>');
+		equal(editor.getContent(),'<table><tbody><tr><td>x</td></tr></tbody></table><p></p><p>x</p>');
 	});
 
 	test('Enter before table element preceded by a p', function() {
@@ -1063,6 +1063,6 @@ if (window.getSelection) {
 		editor.selection.setRng(rng);
 
 		Utils.pressEnter();
-		equal(editor.getContent(),'<p>x</p><p>\u00a0</p><table><tbody><tr><td>x</td></tr></tbody></table>');
+		equal(editor.getContent(),'<p>x</p><p></p><table><tbody><tr><td>x</td></tr></tbody></table>');
 	});
 }

--- a/tests/tinymce/html/DomParser.js
+++ b/tests/tinymce/html/DomParser.js
@@ -306,7 +306,7 @@
 		parser = new tinymce.html.DomParser({}, new tinymce.html.Schema({valid_elements: 'span,a[name],img'}));
 		root = parser.parse('<span></span><a name="anchor"></a>');
 		equal(serializer.serialize(root), '<span></span><a name="anchor"></a>', 'Leave a with name attribute');
-		
+
 		parser = new tinymce.html.DomParser({}, new tinymce.html.Schema({valid_elements: 'span,a[href],img[src]'}));
 		root = parser.parse('<span></span><a href="#"><img src="about:blank" /></a>');
 		equal(serializer.serialize(root), '<span></span><a href="#"><img src="about:blank" /></a>', 'Leave elements with img in it');
@@ -501,5 +501,20 @@
 		root = parser.parse('<p class="classA classB classC"><strong class="classA classB classC">a</strong></p>');
 		equal(serializer.serialize(root), '<p class="classA classB"><strong class="classA classB">a</strong></p>');
 	});
-})();
 
+	test('Remove empty list blocks', function() {
+		var parser, root, schema = new tinymce.html.Schema();
+
+		parser = new tinymce.html.DomParser({}, schema);
+		root = parser.parse('<ul><li></li></ul><ul><li> </li></ul>');
+		equal(serializer.serialize(root), '');
+	});
+
+	test('Preserve space in inline span', function() {
+		var parser, root, schema = new tinymce.html.Schema();
+
+		parser = new tinymce.html.DomParser({}, schema);
+		root = parser.parse('a<span> </span>b');
+		equal(serializer.serialize(root), 'a b');
+	});
+})();

--- a/tests/tinymce/html/DomParser.js
+++ b/tests/tinymce/html/DomParser.js
@@ -323,7 +323,7 @@
 	});
 
 	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
-	/*test('Remove redundant br elements', function() {
+	test.skip('Remove redundant br elements', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		expect(1);
@@ -336,7 +336,7 @@
 			'<p>a<span data-mce-type="bookmark"></span><br></p>'
 		);
 		equal(serializer.serialize(root), '<p>a</p><p>a<br />b</p><p>a<br /><br /></p><p>a<br /><br /></p><p>a</p>', 'Remove traling br elements.');
-	});*/
+	});
 
 	test('Replace br with nbsp when wrapped in two inline elements and one block', function() {
 		var parser, root, schema = new tinymce.html.Schema();
@@ -480,13 +480,13 @@
 	});
 
 	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
-	/*test('Invalid inline element with space before', function() {
+	test.skip('Invalid inline element with space before', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		parser = new tinymce.html.DomParser({}, schema);
 		root = parser.parse('<p><span>1</span> <strong>2</strong></p>');
 		equal(serializer.serialize(root), '<p>1 <strong>2</strong></p>');
-	});*/
+	});
 
 	test('Valid classes', function() {
 		var parser, root, schema = new tinymce.html.Schema({valid_classes: 'classA classB'});
@@ -504,7 +504,8 @@
 		equal(serializer.serialize(root), '<p class="classA classB"><strong class="classA classB">a</strong></p>');
 	});
 
-	test('Remove empty list blocks', function() {
+	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
+	test.skip('Remove empty list blocks', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		parser = new tinymce.html.DomParser({}, schema);
@@ -512,7 +513,8 @@
 		equal(serializer.serialize(root), '');
 	});
 
-	test('Preserve space in inline span', function() {
+	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
+	test.skip('Preserve space in inline span', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		parser = new tinymce.html.DomParser({}, schema);

--- a/tests/tinymce/html/DomParser.js
+++ b/tests/tinymce/html/DomParser.js
@@ -89,7 +89,7 @@
 	test('Whitespace before/after invalid element whitespace element in block', function() {
 		parser = new tinymce.html.DomParser({}, new tinymce.html.Schema({invalid_elements : 'span'}));
 		root = parser.parse('<p> <span></span> </p>');
-		equal(serializer.serialize(root), '<p>\u00a0</p>');
+		equal(serializer.serialize(root), '<p></p>');
 	});
 
 	test('Whitespace preserved in PRE', function() {
@@ -322,7 +322,8 @@
 		equal(serializer.serialize(root), '<ul><li>1</li><li><strong>2</strong></li><li><em><strong>3</strong></em></li></ul>', 'Split out LI elements in LI elements.');
 	});
 
-	test('Remove redundant br elements', function() {
+	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
+	/*test('Remove redundant br elements', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		expect(1);
@@ -335,7 +336,7 @@
 			'<p>a<span data-mce-type="bookmark"></span><br></p>'
 		);
 		equal(serializer.serialize(root), '<p>a</p><p>a<br />b</p><p>a<br /><br /></p><p>a<br /><br /></p><p>a</p>', 'Remove traling br elements.');
-	});
+	});*/
 
 	test('Replace br with nbsp when wrapped in two inline elements and one block', function() {
 		var parser, root, schema = new tinymce.html.Schema();
@@ -478,13 +479,14 @@
 		equal(serializer.serialize(root), '<ul><li>12</li><li>ab</li><li>c</li></ul>');
 	});
 
-	test('Invalid inline element with space before', function() {
+	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
+	/*test('Invalid inline element with space before', function() {
 		var parser, root, schema = new tinymce.html.Schema();
 
 		parser = new tinymce.html.DomParser({}, schema);
 		root = parser.parse('<p><span>1</span> <strong>2</strong></p>');
 		equal(serializer.serialize(root), '<p>1 <strong>2</strong></p>');
-	});
+	});*/
 
 	test('Valid classes', function() {
 		var parser, root, schema = new tinymce.html.Schema({valid_classes: 'classA classB'});

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -566,7 +566,7 @@
 	});
 
 	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
-	/*test('Parse no attributes span before strong', function() {
+	test.skip('Parse no attributes span before strong', function() {
 		var counter, parser;
 
 		counter = createCounter(writer);
@@ -575,7 +575,7 @@
 		writer.reset();
 		parser.parse('<p><span>A</span> <strong>B</strong></p>');
 		equal(writer.getContent(), '<p>A <strong>B</strong></p>');
-	});*/
+	});
 
 	test('Conditional comments (allowed)', function() {
 		var counter, parser;

--- a/tests/tinymce/html/SaxParser.js
+++ b/tests/tinymce/html/SaxParser.js
@@ -565,7 +565,8 @@
 		equal(writer.getContent(), '<a title="\\" href="h">x</a>');
 	});
 
-	test('Parse no attributes span before strong', function() {
+	/* Skip this test as contradictory to https://github.com/Shopify/shopify/pull/8208 */
+	/*test('Parse no attributes span before strong', function() {
 		var counter, parser;
 
 		counter = createCounter(writer);
@@ -574,7 +575,7 @@
 		writer.reset();
 		parser.parse('<p><span>A</span> <strong>B</strong></p>');
 		equal(writer.getContent(), '<p>A <strong>B</strong></p>');
-	});
+	});*/
 
 	test('Conditional comments (allowed)', function() {
 		var counter, parser;


### PR DESCRIPTION
Minor upstream update so we don't start to diverge again. Added `test.skip()` to QUnit so we can explicitly skip tests in codebase rather then commenting them out.

@angelini @nsimmons 