### PR TITLE
Only apply the jQuery patch once

### DIFF
--- a/js/tinymce/classes/jquery.tinymce.js
+++ b/js/tinymce/classes/jquery.tinymce.js
@@ -13,11 +13,12 @@
 (function($) {
 	var undef,
 		lazyLoading,
+		patchApplied,
 		delayedInits = [],
 		win = window;
 
 	$.fn.tinymce = function(settings) {
-		var self = this, url, base, lang, suffix = "", patchApplied;
+		var self = this, url, base, lang, suffix = "";
 
 		// No match then just ignore the call
 		if (!self.length) {

--- a/tests/index.html
+++ b/tests/index.html
@@ -91,6 +91,7 @@
 	<script src="plugins/image.js"></script>
 	<script src="plugins/importcss.js"></script>
 	<script src="plugins/jquery_plugin.js"></script>
+	<script src="plugins/jquery_initialization.js"></script>
 	<script src="plugins/legacyoutput.js"></script>
 	<script src="plugins/link.js"></script>
 	<script src="plugins/lists.js"></script>

--- a/tests/plugins/jquery_initialization.js
+++ b/tests/plugins/jquery_initialization.js
@@ -1,0 +1,40 @@
+module("tinymce.plugins.jQueryInitialization", {
+	setupModule: function() {
+		document.getElementById('view').innerHTML = (
+			'<textarea id="elm1"></textarea>' +
+			'<textarea id="elm2"></textarea>'
+		);
+
+		this.val = $.fn.val;
+
+		QUnit.stop();
+
+		$(function() {
+			QUnit.start();
+		});
+	},
+
+	teardown: function() {
+		$.fn.val = this.val;
+	}
+});
+
+test("applyPatch is only called once", function() {
+	expect(1);
+
+	var options = {plugins: [
+				"pagebreak,layer,table,save,emoticons,insertdatetime,preview,media,searchreplace",
+				"print,contextmenu,paste,directionality,fullscreen,noneditable,visualchars,nonbreaking,template"
+			]},
+		oldValFn;
+
+	$('#elm1').tinymce(options);
+
+	oldValFn = $.fn.val = function() {
+		// no-op
+	};
+
+	$('#elm2').tinymce(options);
+
+	equal($.fn.val, oldValFn);
+});


### PR DESCRIPTION
Duplicate of https://github.com/tinymce/tinymce/pull/463

This prevents applyPatch from being called every time we do a partial refresh. The problem here is that each time we do a partial refresh on a page with tinymce on it, various jQuery functions get wrapped. But each time we call `$(<selector>).tinymce(options)` it re-wraps those functions. Eventually there's so many layers of wrapping that there's a performance hit.

patchApplied was being stored too low, so that applyPatch was only being called once per call to $.tinymce, which isn't much help. Now it'll only be called once per page load.

Review: 
@celsodantas @richardmonette for products
@nsimmons and @jahfer you guys have already touched the tinymce code here. It's a small one, I promise