### PR TITLE
Improve Settings typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,12 +1,13 @@
 import * as tinymce from 'tinymce';
 
-export interface Settings extends tinymce.Settings {
-  [key: string]: any,
-}
-
 declare module 'tinymce' {
-  function init(settings: Settings): Promise<tinymce.Editor[]>;
+  export interface Settings extends tinymce.Settings {
+    [key: string]: any,
+  }
+
+  export function init(settings: Settings): Promise<tinymce.Editor[]>;
+
+  export const shopifyConfig: Settings;
 }
 
-export const shopifyConfig: Settings;
 export * from 'tinymce';


### PR DESCRIPTION
Previously our `Settings` index key was not being picked up by `init`. This fixes that, as well as typing the default `shopifyConfig` as `Settings`.