### PR TITLE
Inline content CSS

### DIFF
--- a/web.js
+++ b/web.js
@@ -5,3 +5,34 @@ require('./plugins/autoresize/plugin.js');
 require('./plugins/table/plugin.js');
 require('./plugins/paste/plugin.js');
 require('./plugins/noparsing/plugin.js');
+
+module.exports.shopifyConfig.content_style = `
+/**
+ * Rich Text Editor
+ * Manages style within the editor iframe
+ **/
+
+html, body {
+  cursor: text;
+}
+
+body {
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  margin: 0;
+}
+
+h1, h2, h3, h4, h5, h6, p {
+  margin: 0 0 1em 0;
+  line-height: 1.4;
+}
+
+table {
+  width: 100%;
+}
+
+table, td, th {
+  border: 1px dashed #CCC;
+}
+`;


### PR DESCRIPTION
This includes our iframe inner CSS directly inline as a setting in the web bundle. TinyMCE will automatically load this string into the iframe. That means if we switch core over to using this module, we will no longer need to rely on serving a separate CSS endpoint for the iframe CSS, and in web we don't need to worry about setting that up in the first place. Mobile can follow a same or similar approach when we add a mobile.js bundle to this module.