### PR TITLE
Fix the issue where Settings recursively references itself

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
 import * as tinymce from 'tinymce';
 
 declare module 'tinymce' {
-  export interface Settings extends tinymce.Settings {
+  export interface ShopifySettings extends tinymce.Settings {
     [key: string]: any,
   }
 
-  export function init(settings: Settings): Promise<tinymce.Editor[]>;
+  export function init(settings: ShopifySettings): Promise<tinymce.Editor[]>;
 
-  export const shopifyConfig: Settings;
+  export const shopifyConfig: ShopifySettings;
 }
 
 export * from 'tinymce';


### PR DESCRIPTION
Fix the TypeScript issue:

```
node_modules/@shopify/tinymce/index.d.ts:4:20 - error TS2310: Type 'Settings' recursively references itself as a base type.
 
4   export interface Settings extends tinymce.Settings {
                     ~~~~~~~~
 ```

The approach taken to resolve this issue is by renaming `Settings` to `ShopifySettings`.