### PR TITLE
Allow preview iframe attributes to be overwritten and await iframe load before initializing

### DIFF
--- a/tinymce.js
+++ b/tinymce.js
@@ -38916,9 +38916,7 @@ define("tinymce/Editor", [
 				}
 			}
 
-			// Create iframe
-			// TODO: ACC add the appropriate description on this.
-			var ifr = DOM.create('iframe', {
+			var options = Object.assign({
 				id: self.id + "_ifr",
 				//src: url || 'about:blank', // Workaround for HTTPS warning in IE6/7
 				frameBorder: '0',
@@ -38932,14 +38930,20 @@ define("tinymce/Editor", [
 					height: h,
 					display: 'block' // Important for Gecko to render the iframe correctly
 				}
-			});
+			}, settings.iframeAttributes);
+
+			// Create iframe
+			// TODO: ACC add the appropriate description on this.
+			var ifr = DOM.create('iframe', options);
+
+			if (!options.src) {
+				DOM.setAttrib(ifr, "src", url || 'about:blank');
+			}
 
 			ifr.onload = function() {
 				ifr.onload = null;
 				self.fire("load");
 			};
-
-			DOM.setAttrib(ifr, "src", url || 'about:blank');
 
 			self.contentAreaContainer = o.iframeContainer;
 			self.iframeElement = ifr;

--- a/tinymce.js
+++ b/tinymce.js
@@ -38941,7 +38941,32 @@ define("tinymce/Editor", [
 			}
 
 			ifr.onload = function() {
+				// Try accessing the document this will fail on IE when document.domain is set to the same as location.hostname
+				// Then we have to force domain relaxing using the domainRelaxUrl approach very ugly!!
+				if (ie) {
+					try {
+						self.getDoc();
+					} catch (e) {
+						n.src = url = domainRelaxUrl;
+					}
+				}
+
+				if (o.editorContainer) {
+					DOM.get(o.editorContainer).style.display = self.orgDisplay;
+					self.hidden = DOM.isHidden(o.editorContainer);
+				}
+
+				self.getElement().style.display = 'none';
+				DOM.setAttrib(self.id, 'aria-hidden', true);
+
+				if (!url) {
+					self.initContentBody();
+				}
+
+				// Cleanup
+				elm = n = o = null;
 				ifr.onload = null;
+
 				self.fire("load");
 			};
 
@@ -38949,30 +38974,6 @@ define("tinymce/Editor", [
 			self.iframeElement = ifr;
 
 			n = DOM.add(o.iframeContainer, ifr);
-
-			// Try accessing the document this will fail on IE when document.domain is set to the same as location.hostname
-			// Then we have to force domain relaxing using the domainRelaxUrl approach very ugly!!
-			if (ie) {
-				try {
-					self.getDoc();
-				} catch (e) {
-					n.src = url = domainRelaxUrl;
-				}
-			}
-
-			if (o.editorContainer) {
-				DOM.get(o.editorContainer).style.display = self.orgDisplay;
-				self.hidden = DOM.isHidden(o.editorContainer);
-			}
-
-			self.getElement().style.display = 'none';
-			DOM.setAttrib(self.id, 'aria-hidden', true);
-
-			if (!url) {
-				self.initContentBody();
-			}
-
-			elm = n = o = null; // Cleanup
 		},
 
 		/**


### PR DESCRIPTION
This PR introduce two changes, though they are closely related:

1- Introduce the `iframeAttributes` setting in order to set / override attributes on the iframe used for the preview of the markup. The main driver for this change is to be able to update the `src` of the iframe in order to have a looser CSP than the parent document (see https://github.com/Shopify/online-store-web/pull/2374 for context). I considered adding the settings one by one, but this approach makes it easier to also add other attributes such as `sandbox`, without needing a specific setting for each attribute.

2- Because the iframe preview src can now be an endpoint serving a blank document with a custom CSP (instead of `about:blank`), we need to wait for the iframe `onload` to fire before trying to write to the document of the iframe. Otherwise, the request is canceled/interrupted.

I have tophatted these changes with and without `settings.iframeAttributes`, as well as with `about:blank` and with a custom iframe preview src